### PR TITLE
NGDC-3216 Issue Fix (inPseudo counter update)

### DIFF
--- a/has-selector.js
+++ b/has-selector.js
@@ -98,6 +98,7 @@
         case "}":
             if (inAtBlck) inAtBlck--;
             if (inStyles) inStyles--;
+            if (inPseudo) inPseudo--;
             outerBgn = f.index + 1;
             break;
 


### PR DESCRIPTION
This fix addresses the following issue:
- The combination of a CSS class definition using a pseudo class
selector, or a pseudo element selector preceeding a CSS class definition
using a :has() selector breaks the polyfill parsing algorythm and that
CSS :has() rule and any others following are not applied.